### PR TITLE
OLED_ can be configured via userPrefs.h

### DIFF
--- a/src/gps/GPS.cpp
+++ b/src/gps/GPS.cpp
@@ -1252,9 +1252,6 @@ GnssModel_t GPS::probe(int serialSpeed)
         LOG_INFO("Aioha AG3335 detected, using AG3335 Module\n");
         return GNSS_MODEL_AG3335;
     }
-    // Get version information for Airoha AG3335
-    clearBuffer();
-    _serial_gps->write("$PMTK605*31\r\n");
 
     // Get version information
     clearBuffer();

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -19,8 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
-#include "Screen.h"
 #include "../userPrefs.h"
+#include "Screen.h"
 #include "PowerMon.h"
 #include "configuration.h"
 #if HAS_SCREEN

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -420,7 +420,7 @@ void RadioInterface::applyModemConfig()
 
             switch (loraConfig.modem_preset) {
             case meshtastic_Config_LoRaConfig_ModemPreset_SHORT_TURBO:
-                bw = (myRegion->wideLora) ? 812.5 : 500;
+                bw = (myRegion->wideLora) ? 1625.0 : 500;
                 cr = 5;
                 sf = 7;
                 break;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -146,7 +146,11 @@ bool PositionModule::hasQualityTimesource()
 {
     bool setFromPhoneOrNtpToday =
         lastSetFromPhoneNtpOrGps == 0 ? false : (millis() - lastSetFromPhoneNtpOrGps) <= (SEC_PER_DAY * 1000UL);
+#if MESHTASTIC_EXCLUDE_GPS
+    bool hasGpsOrRtc = (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
+#else
     bool hasGpsOrRtc = (gps && gps->isConnected()) || (rtc_found.address != ScanI2C::ADDRESS_NONE.address);
+#endif
     return hasGpsOrRtc || setFromPhoneOrNtpToday;
 }
 

--- a/variants/diy/platformio.ini
+++ b/variants/diy/platformio.ini
@@ -7,7 +7,6 @@ build_flags =
   ${esp32_base.build_flags}
   -D DIY_V1
   -D EBYTE_E22
-  -D OLED_RU
   -I variants/diy/v1
 
 ; Meshtastic DIY v1.1 new schematic based on ESP32-WROOM-32 & SX1262/SX1268 modules
@@ -19,7 +18,6 @@ build_flags =
   ${esp32_base.build_flags}
   -D DIY_V1
   -D EBYTE_E22
-  -D OLED_RU
   -I variants/diy/v1_1
 
 ; Port to Disaster Radio's ESP32-v3 Dev Board
@@ -52,7 +50,6 @@ board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/diy/nrf52_promicro_diy_xtal
   -D NRF52_PROMICRO_DIY
-  -D OLED_RU
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/nrf52_promicro_diy_xtal>
 lib_deps = 
@@ -68,7 +65,6 @@ board_level = extra
 build_flags = ${nrf52840_base.build_flags}
   -I variants/diy/nrf52_promicro_diy_tcxo
   -D NRF52_PROMICRO_DIY
-  -D OLED_RU
   -L "${platformio.libdeps_dir}/${this.__env__}/bsec2/src/cortex-m4/fpv4-sp-d16-hard"
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/diy/nrf52_promicro_diy_tcxo>
 lib_deps = 


### PR DESCRIPTION
PR provides new functionality that allows this user to find the OLED display settings through the `userPrefs.h` file, instead of editing the `variant/*/platformio.ini`. This simplifies the configuration process and allows you to save your own settings together in a separate configuration file.

example `userPrefs.h`:

```C

#ifndef _USERPREFS_
#define _USERPREFS_

#define OLED_UA

#endif
```